### PR TITLE
Include more detailed notes and instructions in the attachment upload page

### DIFF
--- a/start
+++ b/start
@@ -4,8 +4,8 @@ ulimit -Sm $((1024 * 256))
 ulimit -Sm $((1024 * 256))
 ulimit -Sc unlimited
 
-~/.local/bin/twistd \
-        --pidfile ~/run/twistd.pid \
-        --logfile ~/log/twistd.log \
-        --rundir ~/run \
-        --python ~/config/server.tac
+~pypy/bin/twistd \
+  --pidfile ~/run/twistd.pid \
+  --logfile ~/log/twistd.log \
+  --rundir ~/run \
+  --python ~/config/server.tac

--- a/start
+++ b/start
@@ -4,8 +4,8 @@ ulimit -Sm $((1024 * 256))
 ulimit -Sm $((1024 * 256))
 ulimit -Sc unlimited
 
-~pypy/bin/twistd \
-	--pidfile ~/run/twistd.pid \
-	--logfile ~/log/twistd.log \
-	--rundir ~/run \
-	--python ~/config/server.tac
+twistd \
+        --pidfile ~/run/twistd.pid \
+        --logfile ~/log/twistd.log \
+        --rundir ~/run \
+        --python ~/config/server.tac

--- a/start
+++ b/start
@@ -4,7 +4,7 @@ ulimit -Sm $((1024 * 256))
 ulimit -Sm $((1024 * 256))
 ulimit -Sc unlimited
 
-twistd \
+~/.local/bin/twistd \
         --pidfile ~/run/twistd.pid \
         --logfile ~/log/twistd.log \
         --rundir ~/run \

--- a/trac-env/templates/site.html
+++ b/trac-env/templates/site.html
@@ -119,48 +119,57 @@
         <div class="span5 alert-danger well">
           <h4>If you are submitting a patch:</h4>
           <ol>
-            <li><strong>Read the <a class="wiki"
-            href="/trac/wiki/TwistedDevelopment#SubmittingaPatch">patch
-            guidelines</a>.</strong></li>
+            <li>
+              <strong>Read the <a class="wiki" href="/trac/wiki/TwistedDevelopment#SubmittingaPatch">patch guidelines</a>.</strong>
+            </li>
 
-            <li><strong>Include unit tests!</strong> if your patch
-            changes code. <a href="/trac/wiki/ReviewProcess">See the
-            complete acceptance criteria</a>.</li>
+            <li>
+              <strong>Include unit tests!</strong> if your patch changes code.
+              <a href="/trac/wiki/ReviewProcess">See the complete acceptance criteria</a>.
+            </li>
 
-            <li><strong>Keep patches as small as possible (&lt;800
-            lines)</strong>. This will make it easy for your change to
-            be reviewed. For larger changes please contact Twisted
-            developers first to discuss how your contribution can be
-            broken into a series of tickets and small patches.</li>
+            <li>
+              <strong>Keep patches as small as possible (&lt;800 lines)</strong>.
+              This will make it easy for your change to be reviewed.
+              For larger changes please contact Twisted developers first
+              to discuss how your contribution can be broken into a series of tickets and small patches.
+            </li>
 
-            <li><strong>Use a standard patch filename</strong>. All
-            lowercase, no spaces, include ticket number, include a
-            patch version number, .patch or .diff extension eg
-            agent-howto-spelling-1234-1.patch</li>
+            <li>
+              <strong>Use a standard patch filename</strong>.
+              All lower case,
+              no spaces,
+              include ticket number,
+              include a patch version number,
+              use a .patch or .diff extension eg agent-howto-spelling-1234-1.patch
+            </li>
 
-            <li><strong>Add the "review" keyword</strong> to the
-            ticket after uploading your patch. This will add the
-            ticket and your patch to the <a class="report"
-            href="/trac/report/15">review queue</a>.</li>
+            <li>
+              <strong>Add the "review" keyword</strong> to the ticket after uploading your patch.
+              This will add your patch to the <a class="report" href="/trac/report/15">review queue</a>.
+            </li>
           </ol>
         </div>
 
         <div class="span5 alert-danger well">
           <h4>If you are submitting an example or demonstration:</h4>
           <ol>
-            <li>Make it a <strong><a class="ext-link"
-            href="http://sscce.org/">Short, Self Contained, Correct
-            Example</a></strong></li>
+            <li>
+              Make it a <strong><a class="ext-link" href="http://sscce.org/">Short, Self Contained, Correct Example</a></strong>
+            </li>
 
-            <li><strong>Include instructions</strong> showing how to run the example and the
-              expected output.</li>
+            <li>
+              <strong>Include instructions</strong>
+              showing how to run the example and the expected output.
+            </li>
           </ol>
         </div>
 
         <div class="span5 alert-danger well">
-          <p>And always <strong>add an explanatory comment to the
-              ticket</strong>, summarising the purpose of your
-            attachment.</p>
+          <p>
+            And always <strong>add an explanatory comment to the ticket</strong>,
+            summarising the purpose of your attachment.
+          </p>
         </div>
       </div>
       <div py:attrs="select('@*')">

--- a/trac-env/templates/site.html
+++ b/trac-env/templates/site.html
@@ -6,9 +6,7 @@
     <head py:match="head">
         <meta name="ROBOTS" content="NOODP" />
         <meta name="Description" content="An event-driven networking engine written in Python and MIT licensed." />
-        <link rel="stylesheet"
-        href="${chrome.htdocs_location}css/bootstrap.min.css" />
-        <link rel="stylesheet" href="${chrome.htdocs_location}css/bootstrap.css" />
+        <link rel="stylesheet" href="${chrome.htdocs_location}css/bootstrap.min.css" />
         <script type="text/javascript" src="${chrome.htdocs_location}js/jquery-1.7.1.min.js"></script>
         ${select('*|comment()|text()')}
         <script type="text/javascript" src="https://www.google.com/jsapi?key=ABQIAAAAJE-f7vmwI1-jxkmwRe4lUxTAs18ELyhzmLGaHoc1qJwmpJy3zhR3LMRRdwqg5PSY4tnVO684msUklQ"></script>

--- a/trac-env/templates/site.html
+++ b/trac-env/templates/site.html
@@ -6,7 +6,9 @@
     <head py:match="head">
         <meta name="ROBOTS" content="NOODP" />
         <meta name="Description" content="An event-driven networking engine written in Python and MIT licensed." />
-        <link rel="stylesheet" href="${chrome.htdocs_location}css/bootstrap.min.css" />
+        <link rel="stylesheet"
+        href="${chrome.htdocs_location}css/bootstrap.min.css" />
+        <link rel="stylesheet" href="${chrome.htdocs_location}css/bootstrap.css" />
         <script type="text/javascript" src="${chrome.htdocs_location}js/jquery-1.7.1.min.js"></script>
         ${select('*|comment()|text()')}
         <script type="text/javascript" src="https://www.google.com/jsapi?key=ABQIAAAAJE-f7vmwI1-jxkmwRe4lUxTAs18ELyhzmLGaHoc1qJwmpJy3zhR3LMRRdwqg5PSY4tnVO684msUklQ"></script>

--- a/trac-env/templates/site.html
+++ b/trac-env/templates/site.html
@@ -128,9 +128,9 @@
         <py:if test="ticket['branch']">
           <br/>
           (<a href="/~diffresource.twistd/${ticket.id}">diff</a>,
-	  <a href="https://github.com/twisted/twisted/compare/trunk...${ticket['branch'][9:]}">github</a>,
-	  <a href="https://buildbot.twistedmatrix.com/boxes-supported?branch=/${ticket['branch']}">buildbot</a>,
-	  <a href="/trac/log/${ticket['branch']}">log</a>)
+          <a href="https://github.com/twisted/twisted/compare/trunk...${ticket['branch'][9:]}">github</a>,
+          <a href="https://buildbot.twistedmatrix.com/boxes-supported?branch=/${ticket['branch']}">buildbot</a>,
+          <a href="/trac/log/${ticket['branch']}">log</a>)
         </py:if>
       </td>
     </py:match>

--- a/trac-env/templates/site.html
+++ b/trac-env/templates/site.html
@@ -114,8 +114,9 @@
 
     <!--! Show a reminder on the attachment page about including tests. -->
     <py:match path="form[@id='attachment']/div[@class='buttons']">
+      <div class="alert-danger">
         <p> Please read this first: </p>
-        <ol class=".alert">
+        <ol>
           <li>If you are submitting a patch:
             <ol>
               <li><strong>Read the <a class="wiki"
@@ -159,7 +160,7 @@
         <p>And always <strong>add an explanatory comment to the
         ticket</strong>, summarising the purpose of your
         attachment.</p>
-
+        </div>
         <div py:attrs="select('@*')">
             ${select('*|comment()|text()')}
         </div>

--- a/trac-env/templates/site.html
+++ b/trac-env/templates/site.html
@@ -114,56 +114,57 @@
 
     <!--! Show a reminder on the attachment page about including tests. -->
     <py:match path="form[@id='attachment']/div[@class='buttons']">
-      <div class="alert-danger">
-        <p> Please read this first: </p>
-        <ol>
-          <li>If you are submitting a patch:
-            <ol>
-              <li><strong>Read the <a class="wiki"
-              href="/trac/wiki/TwistedDevelopment#SubmittingaPatch">patch
-              guidelines</a>.</strong></li>
+      <p>Please read this first:</p>
+      <div class="row-fluid alert">
+        <div class="span5 alert-danger">
+          <h3>If you are submitting a patch:</h3>
+          <ol>
+            <li><strong>Read the <a class="wiki"
+            href="/trac/wiki/TwistedDevelopment#SubmittingaPatch">patch
+            guidelines</a>.</strong></li>
 
-              <li><strong>Include unit tests!</strong> if your patch
-              changes code. <a href="/trac/wiki/ReviewProcess">See the
-              complete acceptance criteria</a>.</li>
+            <li><strong>Include unit tests!</strong> if your patch
+            changes code. <a href="/trac/wiki/ReviewProcess">See the
+            complete acceptance criteria</a>.</li>
 
-              <li><strong>Keep patches as small as possible (&lt;800
-              lines)</strong>. This will make it easy for your change to
-              be reviewed. For larger changes please contact Twisted
-              developers first to discuss how your contribution can be
-              broken into a series of tickets and small patches.</li>
+            <li><strong>Keep patches as small as possible (&lt;800
+            lines)</strong>. This will make it easy for your change to
+            be reviewed. For larger changes please contact Twisted
+            developers first to discuss how your contribution can be
+            broken into a series of tickets and small patches.</li>
 
-              <li><strong>Use a standard patch filename</strong>. All
-              lowercase, no spaces, include ticket number, include a
-              patch version number, .patch or .diff extension eg
-              agent-howto-spelling-1234-1.patch</li>
+            <li><strong>Use a standard patch filename</strong>. All
+            lowercase, no spaces, include ticket number, include a
+            patch version number, .patch or .diff extension eg
+            agent-howto-spelling-1234-1.patch</li>
 
-              <li><strong>Add the "review" keyword</strong> to the
-              ticket after uploading your patch. This will add the
-              ticket and your patch to the <a class="report"
-              href="/trac/report/15">review queue</a>.</li>
-            </ol>
-          </li>
-
-          <li>If you are submitting an example or demonstration:
-            <ol>
-              <li>Make it a <strong><a class="ext-link"
-              href="http://sscce.org/"><span class="icon"> </span>Short,
-              Self Contained, Correct Example</a></strong></li>
-
-              <li><strong>Include instructions</strong> showing how to run the example and the
-                expected output.</li>
-            </ol>
-          </li>
-        </ol>
-
-        <p>And always <strong>add an explanatory comment to the
-        ticket</strong>, summarising the purpose of your
-        attachment.</p>
+            <li><strong>Add the "review" keyword</strong> to the
+            ticket after uploading your patch. This will add the
+            ticket and your patch to the <a class="report"
+            href="/trac/report/15">review queue</a>.</li>
+          </ol>
         </div>
-        <div py:attrs="select('@*')">
-            ${select('*|comment()|text()')}
+
+        <div class="span5 alert-danger">
+          <h3>If you are submitting an example or demonstration:</h3>
+          <ol>
+            <li>Make it a <strong><a class="ext-link"
+            href="http://sscce.org/"><span class="icon"> </span>Short,
+            Self Contained, Correct Example</a></strong></li>
+
+            <li><strong>Include instructions</strong> showing how to run the example and the
+              expected output.</li>
+          </ol>
         </div>
+        <div class="span5 alert-danger">
+          <p>And always <strong>add an explanatory comment to the
+              ticket</strong>, summarising the purpose of your
+            attachment.</p>
+        </div>
+      </div>
+      <div py:attrs="select('@*')">
+        ${select('*|comment()|text()')}
+      </div>
     </py:match>
 
     <!--! Add links to diffresource and buildbot -->

--- a/trac-env/templates/site.html
+++ b/trac-env/templates/site.html
@@ -113,8 +113,8 @@
     <!--! Show a reminder on the attachment page about including tests. -->
     <py:match path="form[@id='attachment']/div[@class='buttons']">
 
-      <div class="row-fluid">
-        <div class="span5 alert-danger well">
+      <div>
+        <div>
           <h4>If you are submitting a patch:</h4>
           <ol>
             <li>
@@ -151,7 +151,7 @@
           </ol>
         </div>
 
-        <div class="span5 alert-danger well">
+        <div>
           <h4>If you are submitting an example or demonstration:</h4>
           <ol>
             <li>
@@ -165,7 +165,7 @@
           </ol>
         </div>
 
-        <div class="span5 alert-danger well">
+        <div>
           <p>
             And after you've attached your file,
             always <strong>add an explanatory comment to the ticket</strong>,

--- a/trac-env/templates/site.html
+++ b/trac-env/templates/site.html
@@ -113,7 +113,7 @@
     <!--! Show a reminder on the attachment page about including tests. -->
     <py:match path="form[@id='attachment']/div[@class='buttons']">
         <p> Please read this first: </p>
-        <ol>
+        <ol class=".alert">
           <li>If you are submitting a patch:
             <ol>
               <li><strong>Read the <a class="wiki"

--- a/trac-env/templates/site.html
+++ b/trac-env/templates/site.html
@@ -114,10 +114,10 @@
 
     <!--! Show a reminder on the attachment page about including tests. -->
     <py:match path="form[@id='attachment']/div[@class='buttons']">
-      <p>Please read this first:</p>
-      <div class="row-fluid alert">
-        <div class="span5 alert-danger">
-          <h3>If you are submitting a patch:</h3>
+
+      <div class="row-fluid">
+        <div class="span5 alert-danger well">
+          <h4>If you are submitting a patch:</h4>
           <ol>
             <li><strong>Read the <a class="wiki"
             href="/trac/wiki/TwistedDevelopment#SubmittingaPatch">patch
@@ -145,18 +145,19 @@
           </ol>
         </div>
 
-        <div class="span5 alert-danger">
-          <h3>If you are submitting an example or demonstration:</h3>
+        <div class="span5 alert-danger well">
+          <h4>If you are submitting an example or demonstration:</h4>
           <ol>
             <li>Make it a <strong><a class="ext-link"
-            href="http://sscce.org/"><span class="icon"> </span>Short,
-            Self Contained, Correct Example</a></strong></li>
+            href="http://sscce.org/">Short, Self Contained, Correct
+            Example</a></strong></li>
 
             <li><strong>Include instructions</strong> showing how to run the example and the
               expected output.</li>
           </ol>
         </div>
-        <div class="span5 alert-danger">
+
+        <div class="span5 alert-danger well">
           <p>And always <strong>add an explanatory comment to the
               ticket</strong>, summarising the purpose of your
             attachment.</p>

--- a/trac-env/templates/site.html
+++ b/trac-env/templates/site.html
@@ -129,17 +129,19 @@
             <li>
               <strong>Keep patches as small as possible (&lt;800 lines)</strong>.
               This will make it easy for your change to be reviewed.
-              For larger changes please contact Twisted developers first
+              For larger changes please contact <a href="/trac/wiki/TwistedCommunity">Twisted developers</a> first
               to discuss how your contribution can be broken into a series of tickets and small patches.
             </li>
 
             <li>
               <strong>Use a standard patch filename</strong>.
-              All lower case,
-              no spaces,
-              include ticket number,
-              include a patch version number,
-              use a .patch or .diff extension eg agent-howto-spelling-1234-1.patch
+              Your patch filename should be
+              all lower case,
+              with no spaces.
+              It should include the ticket number,
+              and a patch version number.
+              Use a .patch or .diff extension so that Trac can apply syntax highlighting.
+              eg agent-howto-spelling-1234-1.patch
             </li>
 
             <li>
@@ -165,7 +167,8 @@
 
         <div class="span5 alert-danger well">
           <p>
-            And always <strong>add an explanatory comment to the ticket</strong>,
+            And after you've attached your file,
+            always <strong>add an explanatory comment to the ticket</strong>,
             summarising the purpose of your attachment.
           </p>
         </div>

--- a/trac-env/templates/site.html
+++ b/trac-env/templates/site.html
@@ -112,10 +112,52 @@
 
     <!--! Show a reminder on the attachment page about including tests. -->
     <py:match path="form[@id='attachment']/div[@class='buttons']">
-        <p>
-        Adding a patch that changes code? Make sure it includes unit tests!
-        <a href="/trac/wiki/ReviewProcess">See the complete acceptance criteria</a>. Thanks!
-        </p>
+        <p> Please read this first: </p>
+        <ol>
+          <li>If you are submitting a patch:
+            <ol>
+              <li><strong>Read the <a class="wiki"
+              href="/trac/wiki/TwistedDevelopment#SubmittingaPatch">patch
+              guidelines</a>.</strong></li>
+
+              <li><strong>Include unit tests!</strong> if your patch
+              changes code. <a href="/trac/wiki/ReviewProcess">See the
+              complete acceptance criteria</a>.</li>
+
+              <li><strong>Keep patches as small as possible (&lt;800
+              lines)</strong>. This will make it easy for your change to
+              be reviewed. For larger changes please contact Twisted
+              developers first to discuss how your contribution can be
+              broken into a series of tickets and small patches.</li>
+
+              <li><strong>Use a standard patch filename</strong>. All
+              lowercase, no spaces, include ticket number, include a
+              patch version number, .patch or .diff extension eg
+              agent-howto-spelling-1234-1.patch</li>
+
+              <li><strong>Add the "review" keyword</strong> to the
+              ticket after uploading your patch. This will add the
+              ticket and your patch to the <a class="report"
+              href="/trac/report/15">review queue</a>.</li>
+            </ol>
+          </li>
+
+          <li>If you are submitting an example or demonstration:
+            <ol>
+              <li>Make it a <strong><a class="ext-link"
+              href="http://sscce.org/"><span class="icon"> </span>Short,
+              Self Contained, Correct Example</a></strong></li>
+
+              <li><strong>Include instructions</strong> showing how to run the example and the
+                expected output.</li>
+            </ol>
+          </li>
+        </ol>
+
+        <p>And always <strong>add an explanatory comment to the
+        ticket</strong>, summarising the purpose of your
+        attachment.</p>
+
         <div py:attrs="select('@*')">
             ${select('*|comment()|text()')}
         </div>

--- a/trac-env/templates/site.html
+++ b/trac-env/templates/site.html
@@ -122,14 +122,15 @@
             </li>
 
             <li>
-              <strong>Include unit tests!</strong> if your patch changes code.
+              <strong>Include unit tests!</strong>
+              If your patch changes code it must include unit tests.
               <a href="/trac/wiki/ReviewProcess">See the complete acceptance criteria</a>.
             </li>
 
             <li>
               <strong>Keep patches as small as possible (&lt;800 lines)</strong>.
               This will make it easy for your change to be reviewed.
-              For larger changes please contact <a href="/trac/wiki/TwistedCommunity">Twisted developers</a> first
+              For larger changes please contact <a href="/trac/wiki/TwistedCommunity">Twisted developers</a> first,
               to discuss how your contribution can be broken into a series of tickets and small patches.
             </li>
 
@@ -169,7 +170,7 @@
           <p>
             And after you've attached your file,
             always <strong>add an explanatory comment to the ticket</strong>,
-            summarising the purpose of your attachment.
+            summarizing the purpose of your attachment.
           </p>
         </div>
       </div>


### PR DESCRIPTION
Adds answers (or links to answers) to some of the most frequent mistakes found in contributed patches directly in the attachment upload page.

I haven't tried building trac-config to test this.
