### PR TITLE
Add a new trac.initdb command to create a default empty trac database

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -128,7 +128,6 @@ class Trac(service.Service):
         """
         Drop the postgresql cluster and recreate with an empty trac database.
         """
-        postgres.newCluster()
         postgres.createUser('trac')
         postgres.createDb('trac', 'trac')
 


### PR DESCRIPTION
It drops the postgres cluster, recreates it and generates the trac default database. It also performs that routine when installing trac.

This depends on https://github.com/twisted-infra/braid/pull/63 to be merged first.

This is the second part of a fix for https://github.com/twisted-infra/braid/issues/54
