### PR TITLE
Update ticket.save_changes in commit hook.

### DIFF
--- a/trac-post-commit-hook
+++ b/trac-post-commit-hook
@@ -172,21 +172,13 @@ class CommitHook:
 
         for tkt_id, cmds in tickets.iteritems():
             try:
-                db = self.env.get_db_cnx()
+                with self.env.db_transaction:
+                    ticket = Ticket(self.env, int(tkt_id))
 
-                ticket = Ticket(self.env, int(tkt_id), db)
-                for cmd in cmds:
-                    cmd(ticket)
+                    for cmd in cmds:
+                        cmd(ticket)
 
-                # determine sequence number...
-                cnum = 0
-                tm = TicketModule(self.env)
-                for change in tm.grouped_changelog_entries(ticket, db):
-                    if change['permanent']:
-                        cnum += 1
-
-                ticket.save_changes(self.author, self.msg, self.now, db, cnum+1)
-                db.commit()
+                    ticket.save_changes(self.author, self.msg, self.now)
 
                 tn = TicketNotifyEmail(self.env)
                 tn.notify(ticket, newticket=0, modtime=self.now)


### PR DESCRIPTION
# Problem

More details #20 

SVN post commit hook uses the old version for Trac 0.11

The new Trac API of Ticket.save_changes uses the cnum argument as a string, but docstring say it is deprecated. https://github.com/edgewall/trac/blob/trunk/trac/ticket/model.py#L313
# Changes

Upgrading the hook is complicated for me as I am not familiar with current infrastructure.
I went for updating only the save_changes part of the hook as found in latest Trac version.

https://github.com/edgewall/trac/blob/eb4c4b586628b3d1262465cce7474346a213a27a/tracopt/ticket/commit_updater.py#L226
# How to test

I am not sure how to test and deploy as I am not familiar with  braid and Twisted infrastructure.

I tried my best to help fixing the hook failure I have observed.
